### PR TITLE
Fix callback names for aliased DSL methods

### DIFF
--- a/lib/after_commit_everywhere.rb
+++ b/lib/after_commit_everywhere.rb
@@ -23,7 +23,7 @@ module AfterCommitEverywhere
   def after_commit(connection: ActiveRecord::Base.connection, &callback)
     AfterCommitEverywhere.register_callback(
       connection: connection,
-      name: __callee__,
+      name: __method__,
       callback: callback,
       no_tx_action: :execute,
     )
@@ -40,12 +40,12 @@ module AfterCommitEverywhere
   # @return           void
   def before_commit(connection: ActiveRecord::Base.connection, &callback)
     if ActiveRecord::VERSION::MAJOR < 5
-      raise NotImplementedError, "#{__callee__} works only with Rails 5.0+"
+      raise NotImplementedError, "#{__method__} works only with Rails 5.0+"
     end
 
     AfterCommitEverywhere.register_callback(
       connection: connection,
-      name: __callee__,
+      name: __method__,
       callback: callback,
       no_tx_action: :warn_and_execute,
     )
@@ -64,7 +64,7 @@ module AfterCommitEverywhere
   def after_rollback(connection: ActiveRecord::Base.connection, &callback)
     AfterCommitEverywhere.register_callback(
       connection: connection,
-      name: __callee__,
+      name: __method__,
       callback: callback,
       no_tx_action: :exception,
     )


### PR DESCRIPTION
It uses `__method__` lookup as callback name instead of `__callee__`.

As described on [stackoverflow](https://stackoverflow.com/questions/35391160/difference-between-callee-and-method), there is a difference:

> __method__ looks up the name statically, it refers to the name of the nearest lexically enclosing method definition. __callee__ looks up the name dynamically, it refers to the name under which the method was called. Neither of the two necessarily needs to correspond to the message that was originally sent:

```ruby
class << (foo = Object.new)
  def bar(*) return __method__, __callee__ end
  alias_method :baz, :bar
  alias_method :method_missing, :baz
end

foo.bar # => [:bar, :bar]
foo.baz # => [:bar, :baz]
foo.qux # => [:bar, :method_missing]
```

Thus, under `__callee__` lookup the aliased DSL method like

```ruby
class MyClass
  include ::AfterCommitEverywhere
  alias_method :aliased_after_commit, :after_commit
end

MyClass.new.aliased_after_commit do
   # some useful stuff
end
```

will land as `:aliased_after_commit` handler to the `Wrap` instance, so will never be executed within `Wrap#committed!` method.