### PR TITLE
Make `no_tx_action` configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Allow to change callbacks' behavior when they are called outside transaction:
+
+  ```ruby
+  AfterCommitEverywhere.after_commit(without_tx: :raise) do
+    # Will be executed only if was called within transaction
+    # Error will be raised otherwise
+  end
+  ```
+
+  Available values for `without_tx` keyword argument:
+   - `:execute` to execute callback immediately
+   - `:warn_and_execute` to print warning and execute immediately
+   - `:raise` to raise an exception instead of executing
+
 ## 1.1.0 (2021-08-05)
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,11 +99,11 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.14.4)
     nio4r (2.5.8)
-    nokogiri (1.12.2)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.2.0)
@@ -111,7 +111,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -203,6 +203,7 @@ DEPENDENCIES
   appraisal
   bundler (~> 2.0)
   isolator (~> 0.7)
+  nokogiri (~> 1.13.3)
   pry
   rails
   rake (~> 13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,7 +203,6 @@ DEPENDENCIES
   appraisal
   bundler (~> 2.0)
   isolator (~> 0.7)
-  nokogiri (~> 1.13.3)
   pry
   rails
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ Please keep in mind ActiveRecord's [limitations for rolling back nested transact
 
 Returns `true` when called inside open transaction, `false` otherwise.
 
+### Available callback options
+
+ - `without_tx` allows to change default callback behavior if called without transaction open.
+
+   Available values:
+    - `:execute` to execute callback immediately
+    - `:warn_and_execute` to print warning and execute immediately
+    - `:raise` to raise an exception instead of executing
+
 ### FAQ
 
 #### Does it works with transactional_test or DatabaseCleaner

--- a/after_commit_everywhere.gemspec
+++ b/after_commit_everywhere.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "isolator", "~> 0.7"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "nokogiri", "~> 1.13.3"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/after_commit_everywhere.gemspec
+++ b/after_commit_everywhere.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "isolator", "~> 0.7"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "nokogiri", "~> 1.13.3"
   spec.add_development_dependency "rails"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/after_commit_everywhere.rb
+++ b/lib/after_commit_everywhere.rb
@@ -18,7 +18,7 @@ module AfterCommitEverywhere
 
   # Causes {before_commit} and {after_commit} to raise an exception when
   # called outside a transaction.
-  EXCEPTION = :exception
+  RAISE = :raise
   # Causes {before_commit} and {after_commit} to execute the given callback
   # immediately when called outside a transaction.
   EXECUTE = :execute
@@ -34,7 +34,7 @@ module AfterCommitEverywhere
     # @param without_tx [Symbol] Determines the behavior of this function when
     #   called without an open transaction.
     #
-    #   Must be one of: {EXCEPTION}, {EXECUTE}, or {WARN_AND_EXECUTE}.
+    #   Must be one of: {RAISE}, {EXECUTE}, or {WARN_AND_EXECUTE}.
     #
     # @param callback   [#call] Callback to be executed
     # @return           void
@@ -59,7 +59,7 @@ module AfterCommitEverywhere
     # @param without_tx [Symbol] Determines the behavior of this function when
     #   called without an open transaction.
     #
-    #   Must be one of: {EXCEPTION}, {EXECUTE}, or {WARN_AND_EXECUTE}.
+    #   Must be one of: {RAISE}, {EXECUTE}, or {WARN_AND_EXECUTE}.
     #
     # @param callback   [#call] Callback to be executed
     # @return           void
@@ -95,7 +95,7 @@ module AfterCommitEverywhere
         connection: connection,
         name: __method__,
         callback: callback,
-        without_tx: EXCEPTION,
+        without_tx: RAISE,
       )
     end
 
@@ -110,7 +110,7 @@ module AfterCommitEverywhere
           return callback.call
         when EXECUTE
           return callback.call
-        when EXCEPTION
+        when RAISE
           raise NotInTransaction, "#{name} is useless outside transaction"
         else
           raise ArgumentError, "Invalid \"without_tx\": \"#{without_tx}\""

--- a/spec/after_commit_everywhere_spec.rb
+++ b/spec/after_commit_everywhere_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AfterCommitEverywhere do
     let(:without_tx) { described_class::EXECUTE }
 
     subject do
-      example_class.new.after_commit(without_tx: without_tx) do
+      example_class.new.after_commit do
         handler.call
         expect(ActiveRecord::Base.connection.transaction_open?).to be_falsey
       end

--- a/spec/after_commit_everywhere_spec.rb
+++ b/spec/after_commit_everywhere_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe AfterCommitEverywhere do
   let(:handler) { spy("handler") }
 
   describe "#after_commit" do
-    let(:no_tx_action) { described_class::EXECUTE }
+    let(:without_tx) { described_class::EXECUTE }
 
     subject do
-      example_class.new.after_commit(no_tx_action) do
+      example_class.new.after_commit(without_tx: without_tx) do
         handler.call
         expect(ActiveRecord::Base.connection.transaction_open?).to be_falsey
       end
@@ -74,8 +74,8 @@ RSpec.describe AfterCommitEverywhere do
         expect { subject }.not_to output.to_stderr
       end
 
-      context "with no_tx_action set to WARN_AND_EXECUTE" do
-        let(:no_tx_action) { described_class::WARN_AND_EXECUTE }
+      context "with without_tx set to WARN_AND_EXECUTE" do
+        let(:without_tx) { described_class::WARN_AND_EXECUTE }
 
         it "logs a warning and executes the block" do
           expect { subject }.to output(anything).to_stderr
@@ -83,8 +83,8 @@ RSpec.describe AfterCommitEverywhere do
         end
       end
 
-      context "with no_tx_action set to EXCEPTION" do
-        let(:no_tx_action) { described_class::EXCEPTION }
+      context "with without_tx set to EXCEPTION" do
+        let(:without_tx) { described_class::EXCEPTION }
 
         it "raises an exception" do
           expect { subject }.to raise_error(
@@ -94,13 +94,13 @@ RSpec.describe AfterCommitEverywhere do
         end
       end
 
-      context "with no_tx_action set to an invalid value" do
-        let(:no_tx_action) { "INVALID-NO-TX-ACTION" }
+      context "with without_tx set to an invalid value" do
+        let(:without_tx) { "INVALID-NO-TX-ACTION" }
 
         it "raises an execption" do
           expect { subject }.to raise_error(
             ArgumentError,
-            "Invalid \"no_tx_action\": \"INVALID-NO-TX-ACTION\""
+            "Invalid \"without_tx\": \"INVALID-NO-TX-ACTION\""
           )
           expect(handler).not_to have_received(:call)
         end
@@ -172,10 +172,10 @@ RSpec.describe AfterCommitEverywhere do
   end
 
   describe "#before_commit" do
-    let(:no_tx_action) { described_class::WARN_AND_EXECUTE }
+    let(:without_tx) { described_class::WARN_AND_EXECUTE }
 
     subject do
-      example_class.new.before_commit(no_tx_action) do
+      example_class.new.before_commit(without_tx: without_tx) do
         handler.call
         expect(ActiveRecord::Base.connection.transaction_open?).to be_truthy
       end
@@ -210,7 +210,11 @@ RSpec.describe AfterCommitEverywhere do
     end
 
     context "without transaction" do
-      subject { example_class.new.before_commit(no_tx_action) { handler.call } }
+      subject do
+        example_class.new.before_commit(without_tx: without_tx) do
+          handler.call
+        end
+      end
 
       it "executes code immediately" do
         subject
@@ -221,8 +225,8 @@ RSpec.describe AfterCommitEverywhere do
         expect { subject }.to output(anything).to_stderr
       end
 
-      context "with no_tx_action set to EXECUTE" do
-        let(:no_tx_action) { described_class::EXECUTE }
+      context "with without_tx set to EXECUTE" do
+        let(:without_tx) { described_class::EXECUTE }
 
         it "executes the handler without logging a warning" do
           expect { subject }.not_to output.to_stderr
@@ -230,8 +234,8 @@ RSpec.describe AfterCommitEverywhere do
         end
       end
 
-      context "with no_tx_action set to EXCEPTION" do
-        let(:no_tx_action) { described_class::EXCEPTION }
+      context "with without_tx set to EXCEPTION" do
+        let(:without_tx) { described_class::EXCEPTION }
 
         it "raises an exception" do
           expect { subject }.to raise_error(
@@ -241,13 +245,13 @@ RSpec.describe AfterCommitEverywhere do
         end
       end
 
-      context "with no_tx_action set to an invalid value" do
-        let(:no_tx_action) { "INVALID-NO-TX-ACTION" }
+      context "with without_tx set to an invalid value" do
+        let(:without_tx) { "INVALID-NO-TX-ACTION" }
 
         it "raises an execption" do
           expect { subject }.to raise_error(
             ArgumentError,
-            "Invalid \"no_tx_action\": \"INVALID-NO-TX-ACTION\""
+            "Invalid \"without_tx\": \"INVALID-NO-TX-ACTION\""
           )
           expect(handler).not_to have_received(:call)
         end

--- a/spec/after_commit_everywhere_spec.rb
+++ b/spec/after_commit_everywhere_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe AfterCommitEverywhere do
         end
       end
 
-      context "with without_tx set to EXCEPTION" do
-        let(:without_tx) { described_class::EXCEPTION }
+      context "with without_tx set to RAISE" do
+        let(:without_tx) { described_class::RAISE }
 
         it "raises an exception" do
           expect { subject }.to raise_error(
@@ -239,8 +239,8 @@ RSpec.describe AfterCommitEverywhere do
         end
       end
 
-      context "with without_tx set to EXCEPTION" do
-        let(:without_tx) { described_class::EXCEPTION }
+      context "with without_tx set to RAISE" do
+        let(:without_tx) { described_class::RAISE }
 
         it "raises an exception" do
           expect { subject }.to raise_error(


### PR DESCRIPTION
There are cases where a user could want to configure the `no_tx_action`
behavior of `before_commit` and `after_commit`.

For example, I have a case where I want to capture a Stripe payment in
an `after_commit` callback. It's important that the API call happen
after other changes have been committed to the database to avoid
charging a customer and then rolling back and leaving our database in a
state where it looks like a customer hasn't paid their bill. In cases
like this I'd prefer to use the `:exception` setting so that running our
test suite on CI will raise if we have a call path that doesn't include
an open transaction.