### PR TITLE
Fix connection leak when no connection open in the current thread

### DIFF
--- a/lib/after_commit_everywhere.rb
+++ b/lib/after_commit_everywhere.rb
@@ -125,7 +125,7 @@ module AfterCommitEverywhere
     # Helper method to determine whether we're currently in transaction or not
     def in_transaction?(connection = nil)
       # Don't establish new connection if not connected: we apparently not in transaction
-      return false unless connection || ActiveRecord::Base.connection_pool.connected?
+      return false unless connection || ActiveRecord::Base.connection_pool.active_connection?
 
       connection ||= default_connection
       # service transactions (tests and database_cleaner) are not joinable


### PR DESCRIPTION
Follow-up for https://github.com/Envek/after_commit_everywhere/pull/21
Fixes https://github.com/Envek/after_commit_everywhere/issues/20

Method `connected?` checks if there are any connections open, even in a different thread,
while `active_connection?` checks for connection owned by current thread.

See:
 - https://api.rubyonrails.org/v5.2.3/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html#method-i-active_connection-3F
 - https://api.rubyonrails.org/v5.2.3/classes/ActiveRecord/ConnectionAdapters/ConnectionPool.html#method-i-connected-3F