### PR TITLE
`use_transaction` to avoid nesting transactions

### DIFF
--- a/lib/after_commit_everywhere.rb
+++ b/lib/after_commit_everywhere.rb
@@ -132,6 +132,16 @@ module AfterCommitEverywhere
       connection.transaction_open? && connection.current_transaction.joinable?
     end
 
+    def use_transaction(connection = nil)
+      connection ||= default_connection
+
+      if in_transaction?(connection)
+        yield
+      else
+        connection.transaction { yield }
+      end
+    end
+
     private
 
     def default_connection

--- a/lib/after_commit_everywhere.rb
+++ b/lib/after_commit_everywhere.rb
@@ -14,7 +14,7 @@ module AfterCommitEverywhere
   class NotInTransaction < RuntimeError; end
 
   delegate :after_commit, :before_commit, :after_rollback, to: AfterCommitEverywhere
-  delegate :in_transaction?, to: AfterCommitEverywhere
+  delegate :in_transaction?, :use_transaction, to: AfterCommitEverywhere
 
   # Causes {before_commit} and {after_commit} to raise an exception when
   # called outside a transaction.

--- a/lib/after_commit_everywhere.rb
+++ b/lib/after_commit_everywhere.rb
@@ -14,7 +14,7 @@ module AfterCommitEverywhere
   class NotInTransaction < RuntimeError; end
 
   delegate :after_commit, :before_commit, :after_rollback, to: AfterCommitEverywhere
-  delegate :in_transaction?, :use_transaction, to: AfterCommitEverywhere
+  delegate :in_transaction?, :in_transaction, to: AfterCommitEverywhere
 
   # Causes {before_commit} and {after_commit} to raise an exception when
   # called outside a transaction.
@@ -132,7 +132,11 @@ module AfterCommitEverywhere
       connection.transaction_open? && connection.current_transaction.joinable?
     end
 
-    def use_transaction(connection = nil)
+    # Makes sure the provided block runs in a transaction. If we are not currently in a transaction, a new transaction is started.
+    #
+    # @param connection [ActiveRecord::ConnectionAdapters::AbstractAdapter] Database connection to operate in. Defaults to +ActiveRecord::Base.connection+
+    # @return           void
+    def in_transaction(connection = nil)
       connection ||= default_connection
 
       if in_transaction?(connection)


### PR DESCRIPTION
Nesting transactions is perilous: https://makandracards.com/makandra/42885-nested-activerecord-transaction-pitfalls

`use_transaction` attempts to simplify that a bit by utilizing `in_transaction?` to determine if it's safe to assume code is already operating in a transaction and avoid issues with active record swallowing `ActiveRecord::Rollback` errors.

The reason I think it makes sense for this to live inside of `after_commit_everywhere` is that the biggest benefits of using `after_commit` come from being in a transaction. But if you're adding `after_commit` callbacks in custom code, it can be very difficult to tell if it's safe to wrap in a transaction or if you might coincidentally get wrapped inside one at a higher level of execution. By utilizing `use_transaction`, you don't have to worry about this situation.

Hopefully that all makes sense, and i'm not missing something!