### PR TITLE
Support prepending callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Will be executed right after transaction in which it have been declared was roll
 
 If called outside transaction will raise an exception!
 
-Please keep in mind ActiveRecord's [limitations for rolling back nested transactions](http://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Nested+transactions). See [`in_transaction`](#in_transaction) for a workaround to this limitation. 
+Please keep in mind ActiveRecord's [limitations for rolling back nested transactions](http://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Nested+transactions). See [`in_transaction`](#in_transaction) for a workaround to this limitation.
 
 ### Available helper methods
 
@@ -139,7 +139,7 @@ class ServiceObjectBtw
 end
 ```
 
-Our service object can run its database operations safely when run in isolation. 
+Our service object can run its database operations safely when run in isolation.
 
 ```rb
 ServiceObjectBtw.new.call # This opens a new #transaction block
@@ -194,6 +194,8 @@ end
     - `:execute` to execute callback immediately
     - `:warn_and_execute` to print warning and execute immediately
     - `:raise` to raise an exception instead of executing
+
+- `prepend` puts the callback at the head of the callback chain, instead of at the end.
 
 ### FAQ
 

--- a/lib/after_commit_everywhere.rb
+++ b/lib/after_commit_everywhere.rb
@@ -124,10 +124,11 @@ module AfterCommitEverywhere
 
       connection ||= default_connection
       wrap = Wrap.new(connection: connection, "#{name}": callback)
-      connection.add_transaction_record(wrap)
+
       if prepend
-        records = connection.current_transaction.instance_variable_get(:@records)
-        records.unshift(records.pop)
+        connection.current_transaction.instance_variable_get(:@records).unshift(wrap)
+      else
+        connection.add_transaction_record(wrap)
       end
     end
 

--- a/spec/after_commit_everywhere_spec.rb
+++ b/spec/after_commit_everywhere_spec.rb
@@ -28,6 +28,34 @@ RSpec.describe AfterCommitEverywhere do
     end
 
     context "within transaction" do
+      context 'when prepend is true' do
+        let(:handler_1) { spy("handler_1") }
+        let(:handler_2) { spy("handler_2") }
+
+        it 'executes prepended callback first' do
+          ActiveRecord::Base.transaction do
+            example_class.new.after_commit { handler_1.call }
+            example_class.new.after_commit(prepend: true) { handler_2.call }
+          end
+          expect(handler_2).to have_received(:call).ordered
+          expect(handler_1).to have_received(:call).ordered
+        end
+      end
+
+      context 'when prepend is not specified' do
+        let(:handler_1) { spy("handler_1") }
+        let(:handler_2) { spy("handler_2") }
+
+        it 'executes callbacks in the order they were defined' do
+          ActiveRecord::Base.transaction do
+            example_class.new.after_commit { handler_1.call }
+            example_class.new.after_commit { handler_2.call }
+          end
+          expect(handler_1).to have_received(:call).ordered
+          expect(handler_2).to have_received(:call).ordered
+        end
+      end
+
       it "executes code only after commit" do
         ActiveRecord::Base.transaction do
           subject


### PR DESCRIPTION
Pass `prepend: true` to put the callback at the head of the callback chain.

In our application's case, the `after_commit` callback `:foo` was specified on a model, an instance of which is modified inside the transaction. We want our custom callback - registered later - to be executed before `:foo`

kudos @A1090 for the heavy lifting 🏋🏻 