### PR TITLE
fixing visibility of CHANGELOG on rubygems.org

### DIFF
--- a/after_commit_everywhere.gemspec
+++ b/after_commit_everywhere.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.metadata["changelog_uri"] = "https://github.com/Envek/after_commit_everywhere/blob/master/CHANGELOG.md"
+
   spec.add_dependency "activerecord", ">= 4.2"
   spec.add_dependency "activesupport"
   spec.add_development_dependency "appraisal"


### PR DESCRIPTION
* this PR adds discoverability of the CHANGELOG.md file from Rubygems.org

It will add this link on the right-hand side:

![Screenshot 2024-02-07 at 07 33 21](https://github.com/Envek/after_commit_everywhere/assets/22553/f59a5b4b-8368-46a2-afae-b6d7e93914d0)
